### PR TITLE
output interfaces instead of classes

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -337,14 +337,11 @@ class Converter {
             if (convertedType === type.id) convertedType = 'any';
             // Add converted source with proper keyword in front
             // This is here instead of in convertType, since that is also used for non root purposes
-            if (type.functions || type.events) {
-                // If it has functions or events it's a class
-                convertedTypes.push(`class ${type.id} ${convertedType}`);
+            if ((type.functions || type.events) || (type.type === 'object' && !type.isInstanceOf)) {
+                // If it has functions or events, or is an object that's not an instance of another one, it's an interface
+                convertedTypes.push(`interface ${type.id} ${convertedType}`);
             } else if (type.enum) {
                 convertedTypes.push(`enum ${this.convertEnumName(type.id)} ${convertedType}`);
-            } else if (type.type === 'object' && !type.isInstanceOf) {
-                // It's an object, that's not an instance of another one
-                convertedTypes.push(`interface ${type.id} ${convertedType}`);
             } else {
                 // It's just a type of some kind
                 convertedTypes.push(`type ${type.id} = ${convertedType};`);


### PR DESCRIPTION
this affects these:

 * [`browser.events.Event`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/events/Event)
 * [`browser.storage.StorageArea`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/storage/StorageArea)
 * [`browser.types.Setting`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/types/BrowserSetting) (named `BrowserSetting` on mdn)
 * `browser.devtools.inspectedWindow.Resource` (no mdn page)
 * `browser.devtools.network.Resource` (no mdn page)
 * [`browser.devtools.panels.ElementsPanel`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/devtools.panels/ElementsPanel)
 * `browser.devtools.panels.SourcesPanel` (no mdn page)
 * [`browser.devtools.panels.ExtensionPanel`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/devtools.panels/ExtensionPanel)
 * [`browser.devtools.panels.ExtensionSidebarPane`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/devtools.panels/ExtensionSidebarPane)
 * `browser.devtools.panels.Button` (no mdn page)

generating `class` for them means they can be constructed from typescript code, but all of them are actually undefined in js land (the devtools namespace is only visible on [devtools pages](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/devtools_page))

`interface` for these definitions will work the same as before except that they'll be only considered types in typescript so you can't use them as values or construct them