### PR TITLE
add message parameter to sendResponse in message events

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -170,6 +170,10 @@ class Converter {
     }
 
     convertType(type, root = false) {
+        // Check if we've overridden it, likely for a type that can't be represented in json schema
+        if (type.converterTypeOverride) {
+            return type.converterTypeOverride;
+        }
         let out = '';
         // Check type of type
         if (type.choices) {

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ for (let path of [
         {
             name: 'response',
             type: 'any',
+            optional: true,
         }
     ];
     return x;

--- a/index.js
+++ b/index.js
@@ -63,6 +63,13 @@ for (let path of [
 ]) converter.edit(...path, x => {
     // The message parameter actually isn't optional
     x.parameters[0].optional = false;
+    // Add a missing parameter to sendResponse
+    x.parameters[2].parameters = [
+        {
+            name: 'response',
+            type: 'any',
+        }
+    ];
     return x;
 });
 

--- a/index.js
+++ b/index.js
@@ -71,6 +71,10 @@ for (let path of [
             optional: true,
         }
     ];
+    // Runtime events only: Add "Promise<any>" return type, the result gets passed to sendResponse
+    if (path[0] === 'runtime') {
+        x.returns.converterTypeOverride = 'boolean | Promise<any>';
+    }
     return x;
 });
 


### PR DESCRIPTION
it's not there in the schema for some reason

i wanted to also fix the return type of the event callback to `boolean | Promise<any> | void` but:

- i don't know what `Promise<any>` is in json schema
- i think the lack of void is caused by the converter not supporting `optional` in `returns`? it seems a bit more complex to fix and you might do it better than me
  ```json
  "returns": {
    "type": "boolean",
    "optional": true,
    "description": "Return true from the event listener if you wish to call <code>sendResponse</code> after the event listener returns."
  }
  ```

the `Promise` return value just sends a response asynchronously [as described here](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/onMessage), so the type is any