### PR TITLE
fix comments for functions with multiple signatures

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -561,7 +561,7 @@ class Converter {
         // The rest of the parameters
         let rest = [];
         for (let [i, param] of (func.parameters || []).entries()) {
-            if (isLeadingOptional(parameters, i)) {
+            if (isLeadingOptional(func.parameters, i)) {
                 // It won't be optional in the overload signature, so create a copy of it marked as non-optional
                 leadingOptionals.push({...param, optional: false});
             } else {


### PR DESCRIPTION
for https://github.com/bomjacob/definitelytyped-firefox-webext-browser/pull/3#issuecomment-351145296

before:

```typescript
/**
 * Creates and displays a notification.
 * @param [notificationId] Identifier of the notification. If it is empty, this method generates an id. If it matches an existing notification, this method first clears that notification before proceeding with the create operation.
 * @param options Contents of the notification.
 */
function create(options: CreateNotificationOptions): Promise<string | void>;
function create(notificationId: string, options: CreateNotificationOptions): Promise<string | void>;
```

after:

```typescript
/**
 * Creates and displays a notification.
 * @param options Contents of the notification.
 */
function create(options: CreateNotificationOptions): Promise<string | void>;
/**
 * Creates and displays a notification.
 * @param notificationId Identifier of the notification. If it is empty, this method generates an id. If it matches an existing notification, this method first clears that notification before proceeding with the create operation.
 * @param options Contents of the notification.
 */
function create(notificationId: string, options: CreateNotificationOptions): Promise<string | void>;
```