### PR TITLE
Fix return handling of functions and events

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -542,6 +542,9 @@ class Converter {
                 func.returns = {converterTypeOverride: returnType};
                 // Converted now
                 delete func.async;
+            } else {
+                // Since it's async it's gotta return a promise... the type just isn't specified in the schemas
+                returnType = 'Promise<any>';
             }
         }
 

--- a/converter.js
+++ b/converter.js
@@ -512,10 +512,10 @@ class Converter {
         if (func.returns) {
             returnType = this.convertType(func.returns);
             if (func.returns.optional && !ALREADY_OPTIONAL_RETURNS.includes(returnType)) returnType += ' | void';
-        } else if (func.async) {
-            if (func.async === true) func.async = 'callback';
+        } else {
+            if (func.async === undefined) func.async = 'callback';
             // If it's async then find the callback function and convert it to a promise
-            let callback = func.parameters.find(x => x.type === 'function' && x.name === func.async);
+            let callback = func.parameters && func.parameters.find(x => x.type === 'function' && x.name === func.async);
             if (callback) {
                 // Remove callback from parameters as we're gonna handle it as a promise return
                 func.parameters = func.parameters.filter(x => x !== callback);
@@ -542,7 +542,7 @@ class Converter {
                 func.returns = {converterTypeOverride: returnType};
                 // Converted now
                 delete func.async;
-            } else {
+            } else if (func.async && func.async !== 'callback') {
                 // Since it's async it's gotta return a promise... the type just isn't specified in the schemas
                 returnType = 'Promise<any>';
             }

--- a/converter.js
+++ b/converter.js
@@ -475,8 +475,6 @@ class Converter {
         let convertedParameters = [];
         // For each parameter
         for (let parameter of Object.keys(parameters)) {
-            // If it's a function and that function is 'callback' we skip it since we don't use callbacks but promises instead
-            if (parameters[parameter].type && parameters[parameter].name && parameters[parameter].type === 'function' && parameters[parameter].name === 'callback') continue;
             let out = '';
             // If includeName then include the name (add ? if optional)
             if (includeName) out += `${parameters[parameter].name ? parameters[parameter].name : parameter}${parameters[parameter].optional ? '?' : ''}: `;
@@ -515,6 +513,7 @@ class Converter {
             returnType = this.convertType(func.returns);
             if (func.returns.optional && !ALREADY_OPTIONAL_RETURNS.includes(returnType)) returnType += ' | void';
         } else if (func.async) {
+            if (func.async === true) func.async = 'callback';
             // If it's async then find the callback function and convert it to a promise
             let callback = func.parameters.find(x => x.type === 'function' && x.name === func.async);
             if (callback) {

--- a/converter.js
+++ b/converter.js
@@ -537,35 +537,13 @@ class Converter {
                 // Note that the join is kinda useless (see long comments above)
                 let promiseReturn = parameters[0] || 'void';
                 if (callback.optional && !ALREADY_OPTIONAL_RETURNS.includes(promiseReturn)) promiseReturn += ' | void';
-                returnType = `Promise<${promiseReturn}>`
+                returnType = `Promise<${promiseReturn}>`;
                 // Because of namespace extends(?), a few functions can pass through here twice,
                 // so override the return type since the callback was removed and it can't be converted again
                 func.returns = {converterTypeOverride: returnType};
                 // Converted now
                 delete func.async;
             }
-        }
-            let callbackIndex = func.parameters.findIndex(x => x.type === 'function' && x.name === 'callback');
-            // Delete the callback parameter
-            let callback = func.parameters.splice(callbackIndex, 1)[0];
-            let parameters = this.convertParameters(callback.parameters, false, func.name);
-            if (parameters.length > 1) {
-                // Since these files are originally chrome, some things are a bit weird
-                // Callbacks (which is what chrome uses) have no issues with returning multiple values
-                // but firefox uses promises, which AFAIK can't handle that
-                // This doesn't seem to be a problem yet, as firefox hasn't actually implemented the methods in question yet
-                // But since it's in the schemas, it's still a problem for us
-                // TODO: Follow firefox developments in this area
-                console.log(`Warning: Promises cannot return more than one value: ${func.name}.`);
-                // Just assume it's gonna be some kind of object that's returned from the promise
-                // This seems like the most likely way the firefox team is going to make the promise return multiple values
-                parameters = ['object']
-            }
-            // Use void as return type if there were no parameters
-            // Note that the join is kinda useless (see long comments above)
-            let promiseReturn = parameters[0] || 'void';
-            if (callback.optional && !ALREADY_OPTIONAL_RETURNS.includes(promiseReturn)) promiseReturn += ' | void';
-            returnType = `Promise<${promiseReturn}>`
         }
 
         // Create overload signatures for leading optional parameters

--- a/converter.js
+++ b/converter.js
@@ -74,8 +74,6 @@ function commentFromSchema(schema) {
     }
     if (schema.parameters) {
         for (let param of schema.parameters) {
-            // Callbacks are skipped in other parts of the code as well
-            if (param.type === 'function' && param.name === 'callback') continue;
             // Square brackets around optional parameter names is a jsdoc convention
             let name = (param.optional) ? `[${param.name}]` : param.name;
             let desc = (param.description) ? ' ' + descToMarkdown(param.description) : '';

--- a/converter.js
+++ b/converter.js
@@ -584,7 +584,7 @@ class Converter {
         if (extra) {
             // It has extra parameters, so output custom event handler
             let listenerName = '_' + this.convertName(`${this.namespace}_${name}_Event`);
-            this.additionalTypes.push(`type ${listenerName}<T = (${parameters.join(', ')}) => void> = WebExtEventBase<(callback: T, ${extra.join(', ')}) => void, T>;`);
+            this.additionalTypes.push(`type ${listenerName}<T = (${parameters.join(', ')}) => ${returnType}> = WebExtEventBase<(callback: T, ${extra.join(', ')}) => void, T>;`);
             return `${listenerName}`;
         } else {
             // It has no extra parameters, so just use the helper that we define in HEADER

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ for (let path of [
     // Return type of the callback is weirder than the schemas can express
     x.returns.converterTypeOverride = 'BlockingResponse | Promise<BlockingResponse>';
     // It's also optional, since you can choose to just listen to the event
-    x.returns.options = true;
+    x.returns.optional = true;
     return x;
 });
 

--- a/index.js
+++ b/index.js
@@ -92,6 +92,43 @@ for (let path of [
     x.returns.optional = true;
     return x;
 });
+// Fix webrequest events
+for (let path of [
+    ['webRequest', 'events', 'onAuthRequired'],
+    ['webRequest', 'events', 'onBeforeRequest'],
+    ['webRequest', 'events', 'onBeforeSendHeaders'],
+    ['webRequest', 'events', 'onHeadersReceived'],
+]) converter.edit(...path, x => {
+    // Return type of the callback is weirder than the schemas can express
+    x.returns.converterTypeOverride = 'BlockingResponse | Promise<BlockingResponse>';
+    // It's also optional, since you can choose to just listen to the event
+    x.returns.optional = true;
+    return x;
+});
+// Fix the lack of promise return in functions that firefox has but chrome doesn't
+for (let func of [
+    ['sessions', 'functions', 'setTabValue', 'Promise<void>'],
+    ['sessions', 'functions', 'getTabValue', 'Promise<string | object | undefined>'],
+    ['sessions', 'functions', 'removeTabValue', 'Promise<void>'],
+    ['sessions', 'functions', 'setWindowValue', 'Promise<void>'],
+    ['sessions', 'functions', 'getWindowValue', 'Promise<string | object | undefined>'],
+    ['sessions', 'functions', 'removeWindowValue', 'Promise<void>'],
+    ['sessions', 'functions', 'forgetClosedTab', 'Promise<void>'],
+    ['sessions', 'functions', 'forgetClosedWindow', 'Promise<void>'],
+    ['sessions', 'functions', 'getRecentlyClosed', 'Promise<Session[]>'],
+    ['sessions', 'functions', 'restore', 'Promise<Session>'],
+    ['sidebarAction', 'functions', 'close', 'Promise<void>'],
+    ['sidebarAction', 'functions', 'open', 'Promise<void>'],
+    ['sidebarAction', 'functions', 'setPanel', 'Promise<void>'],
+    ['sidebarAction', 'functions', 'setIcon', 'Promise<void>'],
+    ['sidebarAction', 'functions', 'setTitle', 'Promise<void>'],
+    ['sidebarAction', 'functions', 'getPanel', 'Promise<string>'],
+    ['sidebarAction', 'functions', 'getTitle', 'Promise<string>'],
+    [... continued]
+]) converter.edit(func[0], func[1], func[2], y => {
+    y.returns = {converterTypeOverride: func[3]};
+    return y;
+});
 
 converter.convert();
 converter.write(argv['o']);

--- a/index.js
+++ b/index.js
@@ -79,6 +79,19 @@ for (let path of [
     }
     return x;
 });
+// Fix webrequest events
+for (let path of [
+    ['webRequest', 'events', 'onAuthRequired'],
+    ['webRequest', 'events', 'onBeforeRequest'],
+    ['webRequest', 'events', 'onBeforeSendHeaders'],
+    ['webRequest', 'events', 'onHeadersReceived'],
+]) converter.edit(...path, x => {
+    // Return type of the callback is weirder than the schemas can express
+    x.returns.converterTypeOverride = 'BlockingResponse | Promise<BlockingResponse>';
+    // It's also optional, since you can choose to just listen to the event
+    x.returns.options = true;
+    return x;
+});
 
 converter.convert();
 converter.write(argv['o']);

--- a/index.js
+++ b/index.js
@@ -106,28 +106,75 @@ for (let path of [
     return x;
 });
 // Fix the lack of promise return in functions that firefox has but chrome doesn't
-for (let func of [
-    ['sessions', 'functions', 'setTabValue', 'Promise<void>'],
-    ['sessions', 'functions', 'getTabValue', 'Promise<string | object | undefined>'],
-    ['sessions', 'functions', 'removeTabValue', 'Promise<void>'],
-    ['sessions', 'functions', 'setWindowValue', 'Promise<void>'],
-    ['sessions', 'functions', 'getWindowValue', 'Promise<string | object | undefined>'],
-    ['sessions', 'functions', 'removeWindowValue', 'Promise<void>'],
-    ['sessions', 'functions', 'forgetClosedTab', 'Promise<void>'],
-    ['sessions', 'functions', 'forgetClosedWindow', 'Promise<void>'],
-    ['sessions', 'functions', 'getRecentlyClosed', 'Promise<Session[]>'],
-    ['sessions', 'functions', 'restore', 'Promise<Session>'],
-    ['sidebarAction', 'functions', 'close', 'Promise<void>'],
-    ['sidebarAction', 'functions', 'open', 'Promise<void>'],
-    ['sidebarAction', 'functions', 'setPanel', 'Promise<void>'],
-    ['sidebarAction', 'functions', 'setIcon', 'Promise<void>'],
-    ['sidebarAction', 'functions', 'setTitle', 'Promise<void>'],
-    ['sidebarAction', 'functions', 'getPanel', 'Promise<string>'],
-    ['sidebarAction', 'functions', 'getTitle', 'Promise<string>'],
-]) converter.edit(func[0], func[1], func[2], x => {
-    x.returns = {converterTypeOverride: func[3]};
-    return x;
-});
+for (let [namespace, funcs] of [
+    ['clipboard', [['setImageData', 'void']]],
+    ['contextualIdentities', [
+        ['create', 'ContextualIdentity'],
+        ['get', 'ContextualIdentity'],
+        ['query', 'ContextualIdentity[]'],
+        ['remove', 'ContextualIdentity'],
+        ['update', 'ContextualIdentity']
+    ]],
+    ['proxy', [
+        ['register', 'void'],
+        ['unregister', 'void']
+    ]],
+    ['theme', [
+        ['getCurrent', '_manifest.ThemeType'],
+        ['reset', false],
+        ['update', false]
+    ]],
+    ['browserAction', [['openPopup', 'void']]],
+    ['find', [
+        ['find', '{\ncount: number;\nrangeData?: Array<{\nframePos: number;\nstartTextNodePos: number;\nendTextNodePos: number;\nstartOffset: number;\nendOffset: number;\n}>;\nrectData?: Array<{\nrectsAndTexts: {\nrectList: Array<{\ntop: number;\nleft: number;\nbottom: number;\nright: number;\n}>;\ntextList: string[];\n};\ntextList: string;\n}>;\n}'],
+        ['highlightResults', false],
+        ['removeHighlighting', false]
+    ]],
+    ['pageAction', [
+        ['setPopup', false],
+        ['openPopup', 'void']
+    ]],
+    ['pkcs11', [
+        ['getModuleSlots', '{\nname: string;\ntoken?: {\nname: string;\nmanufacturer: string;\nHWVersion: string;\nFWVersion: string;\nserial: string;\nisLoggedIn: string;\n};\n}'],
+        ['installModule', 'void'],
+        ['isModuleInstalled', 'boolean'],
+        ['uninstallModule', 'void']
+    ]],
+    ['sessions', [
+        ['setTabValue', 'void'],
+        ['getTabValue', 'string | object | undefined'],
+        ['removeTabValue', 'void'],
+        ['setWindowValue', 'void'],
+        ['getWindowValue', 'string | object | undefined'],
+        ['removeWindowValue', 'void'],
+        ['forgetClosedTab', 'void'],
+        ['forgetClosedWindow', 'void'],
+        ['getRecentlyClosed', 'Session[]'],
+        ['restore', 'Session']
+    ]],
+    ['sidebarAction', [
+        ['close', 'void'],
+        ['open', 'void'],
+        ['setPanel', 'void'],
+        ['setIcon', 'void'],
+        ['setTitle', 'void'],
+        ['getPanel', 'string'],
+        ['getTitle', 'string']
+    ]],
+    ['tabs', [
+        ['discard', 'void'],
+        ['toggleReaderMode', 'void']
+    ]]
+]) {
+    for (let [name, ret] of funcs) converter.edit(namespace, 'functions', name, x => {
+        if (ret) {
+            x.returns = {converterTypeOverride: `Promise<${ret}>`};
+        } else {
+            x.returns = {converterTypeOverride: 'void'};
+        }
+        return x;
+    });
+}
 // Prevent some of Event from being promisified
 converter.edit('events', 'types', 'Event', x => {
     for (let f of x.functions.slice(0,3)) {

--- a/index.js
+++ b/index.js
@@ -124,11 +124,24 @@ for (let func of [
     ['sidebarAction', 'functions', 'setTitle', 'Promise<void>'],
     ['sidebarAction', 'functions', 'getPanel', 'Promise<string>'],
     ['sidebarAction', 'functions', 'getTitle', 'Promise<string>'],
-    [... continued]
-]) converter.edit(func[0], func[1], func[2], y => {
-    y.returns = {converterTypeOverride: func[3]};
-    return y;
+]) converter.edit(func[0], func[1], func[2], x => {
+    x.returns = {converterTypeOverride: func[3]};
+    return x;
 });
+// Prevent some of Event from being promisified
+converter.edit('events', 'types', 'Event', x => {
+    for (let f of x.functions.slice(0,3)) {
+        f.async = false;
+    }
+    console.log(x);
+    return x;
+});
+// This should prob also not return promise
+converter.edit('devtools.panels', 'types', 'ElementsPanel', x => {
+    x.functions[0].async = false;
+    return x;
+});
+
 
 converter.convert();
 converter.write(argv['o']);


### PR DESCRIPTION
Fixes #10 
Fixes #11 

- Allows other `async:` functions than just `async: 'callback'`
- Remove the callback parameter when it's gotten converted to a promise (this means we don't need to exclude it in the comment handler)
- And can therefore remove the callback exclude from the comment code

Also fixes (cause I stumbled upon the issues while fixes the stuff above)
- Custom events were ignoring custom callback return types
- Some webRequest events' callbacks can return either a BlockingResponse object or a promise resolving to such - this was not expressed in the schema at all as far as I could tell